### PR TITLE
Fix cucumber setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "haml-rails", "~> 1.0"
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'cucumber-rails', '~> 1.6'
+  gem 'cucumber-rails', '~> 1.6', require: false
   gem 'database_cleaner'
 end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
### [Bug Fix] - Fix cucumber setup
### PT no pivotal tracker story

We had an issue where cucumber was required in the wrong environment on CI and locally, preventing the build from running successfully. To fix this we had to add `require: false` next to the `cucumber-rails` gem

### What we have learned
- Follow the documentation of gems when we're setting them up in our applications.

### What we did
- Add `gem 'cucumber-rails', '~> 1.6', require: false´`
- Run migration to generate `schema.rb` file required in CI 